### PR TITLE
Allow passing in host and port for server connect

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -6,14 +6,8 @@ var EventEmitter = require('events').EventEmitter;
 function Connection(opt){
   EventEmitter.call(this);
   this.options = opt || {};
-  // this.socket = io.connect(this.options.host, {
-  //   port: this.options.port
-  // });
-  // this.socket = io.connect("localhost", {
-  //   port: 3000
-  // });
-  this.socket = io.connect("http://skynet.im", {
-    port: 80
+  this.socket = io.connect(this.options.host || "http://skynet.im", {
+    port: this.options.port || 80
   });
 
   // mqttclient connection
@@ -30,8 +24,7 @@ function Connection(opt){
     }
 
     try {
-      // this.mqttclient = mqtt.createClient(1883, 'localhost', mqttsettings);
-      this.mqttclient = mqtt.createClient(1883, 'mqtt.skynet.im', this.mqttsettings);
+      this.mqttclient = mqtt.createClient(this.options.mqttport || 1883, this.options.mqtthost || 'mqtt.skynet.im', this.mqttsettings);
 
       this.mqttclient.subscribe(this.options.uuid, {qos: this.options.qos});
       this.mqttclient.subscribe('broadcast', {qos: this.options.qos});


### PR DESCRIPTION
Allow passing in host and port for calling createConnection, with sensible default values.

Example for local development:

``` javascript
var conn = skynet.createConnection({
  "uuid": "742401f1-87a4-11e3-834d-670dadc0ddbf",
  "token": "xjq9h3yzhemf5hfrme8y08fh0sm50zfr",
  "protocol": "mqtt",
  "host": "localhost",
  "port": 3000
});
```

Example using defaults to skynet.im server on port 80:

``` javascript
var conn = skynet.createConnection({
  "uuid": "742401f1-87a4-11e3-834d-670dadc0ddbf",
  "token": "xjq9h3yzhemf5hfrme8y08fh0sm50zfr",
  "protocol": "mqtt"
});
```
